### PR TITLE
Included pdf parsing and error handling

### DIFF
--- a/backend/flaskApi.py
+++ b/backend/flaskApi.py
@@ -1,32 +1,70 @@
 from flask import Flask, jsonify, request
-#import inference.py 
+import inference
+import os
 import urllib.request
 
+UPLOAD_FOLDER = '/tmp'
 app = Flask(__name__)
 app.config["DEBUG"] = True
-
-burtWeights = None
-
-def analyze():
-    # Run analysis on received data
-    return
+app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 
 @app.route('/pdf', methods=['POST'])
 def analyzePdf():
-    # Extract text from pdf
-    # Call functions imported from innference.py
-    # Return important information
-    req_json = request.get_json()
+    # Check if file exists
+    if 'file' not in request.files:
+        return jsonify({'classification':'None', 'summary':'None', 'error':'Files not included in Request.'})
     
-    return jsonify({'msg':'Request should be pdf. Seems to work properly'})
+    uploaded_file = request.files['file']
+    filename = uploaded_file.filename
+
+    # Check if file has a name
+    if filename == '':
+        return jsonify({'classification':'None', 'summary':'None', 'error':'File either has no name or no file uploaded.'})
+
+    # Check if file extension is .pdf
+    if filename.rsplit('.', 1)[1].lower() != 'pdf':
+        return jsonify({'classification':'None', 'summary':'None', 'error':'File must have file extension .pdf'})
+
+    # Save file
+    uploaded_file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
+    
+    # Read/Convert file
+    path = UPLOAD_FOLDER + '/' + filename
+    #text = convert_pdf(path)
+
+    # Create EULA class and run inference
+    eula = inference.EULA(None, path)
+    infer = inference.Inference()
+    classification = infer.getEthicalityClassifiation(eula)
+    summary = infer.getEULASummary(eula)
+    
+    # Delete file
+    os.remove(UPLOAD_FOLDER + '/' + filename)
+
+    # Format return message
+    return jsonify({'classification':classification, 'summary':summary, 'error':'None'})
+
 
 @app.route('/text', methods=['POST'])
 def analyzeText():
-    # Call functions imported from innference.py
-    # Return important information
-    req_json = request.get_json()
+    if 'text' not in request.form:
+        return jsonify({'classification':'None', 'summary':'None', 'error':'Text not included in request.'})
+
+    text = request.form['text']
     
-    return jsonify({'msg':'Request should be string. Seems to work properly'})
+    if not isinstance(text, str):
+        return jsonify({'classification':'None', 'summary':'None', 'error':'Data in incorrect format'})
+    elif text == '':
+        return jsonify({'classification':'None', 'summary':'None', 'error':'No text received'})
+
+    # Create EULA class and run inference
+    eula = inference.EULA(text, None)
+    infer = inference.Inference()
+    classification = infer.getEthicalityClassification(eula)
+    summary = infer.getEULASummary(eula)
+
+    # Format return message    
+    return jsonify({'classification':classification, 'summary':summary, 'error':'None'})
 
 if __name__ == '__main__':
     app.run()

--- a/backend/inference.py
+++ b/backend/inference.py
@@ -5,6 +5,48 @@ from transformers import pipeline
 from data import get_tokenizer, InferenceDataset
 from models import get_pretrained_model
 
+from io import StringIO
+from pdfminer.converter import TextConverter
+from pdfminer.layout import LAParams
+from pdfminer.pdfdocument import PDFDocument
+from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
+from pdfminer.pdfpage import PDFPage
+from pdfminer.pdfparser import PDFParser
+# Uses pdfminer.six to parse through the pdf. Example can be found at
+# https://pdfminersix.readthedocs.io/en/latest/tutorial/composable.html
+
+# Trims any beginning non-alphabet letters
+def trim(string:str):
+    index = 0
+    for i in range(len(string)):
+      if string[i].isalpha():
+        break
+      index = index + 1
+    return string[index:]
+
+# Processes text to better fit inference's expected value
+def processText(text):
+    text = text.strip()
+    textList = text.split('\n')
+    newText = ''
+    addNewline = True
+    for line in textList:
+      # Remove duplicate white space
+      temp = ' '.join(line.split())
+      # Trim any beginning non-alphabet letters
+      temp = trim(temp)
+      # Remove overly short lines, but keep ends of sentences
+      # Add a newline if gap detected
+      if len(temp) < 40 and not '.' in temp:
+        if addNewline:
+          newText += '\n'
+          addNewline = False
+        continue
+      # Add line to growing string
+      newText += temp + ' '
+      addNewline = True
+    return newText
+  
 
 class Inference():
   def __init__(self):
@@ -34,7 +76,27 @@ class Inference():
 
 class EULA:
   def __init__(self, text, pdf=None):
-    raise NotImplementedError
+    if pdf == None and text != None:
+      self.text = processText(text)
+      return
+    elif pdf == None and text == None:
+      raise Exception('EULA initialization failed')
+
+    output_string = StringIO()
+    readFile = open(pdf, 'rb')
+    with readFile as in_file:
+      parser = PDFParser(in_file)
+      doc = PDFDocument(parser)
+      rsrcmgr = PDFResourceManager()
+      device = TextConverter(rsrcmgr, output_string, laparams=LAParams())
+      interpreter = PDFPageInterpreter(rsrcmgr, device)
+      for page in PDFPage.create_pages(doc):
+        interpreter.process_page(page)
+    readFile.close()
+
+    self.text = processText(output_string.getvalue())
 
   def getText(self):
-    raise NotImplementedError
+    return self.text
+
+


### PR DESCRIPTION
ChangeLog:
- Added pdf to text conversion
- Added processing of text before inference
- Added error messages/handling for both text/pdf options
- Added inference call and returns output to frontend

Requirements:
- Frontend must pass files in the request under the key 'file'
- Frontend must pass text in the request under the key 'text'
- Frontend calls the proper URL (there is one for each)

TODO:
- [Optional] Text pre-processing can be further enhanced

Testing:
- Used Postman to send text and files under both URLs to the server

Closes #6 
Closes #8 